### PR TITLE
Adjust tslint zero based line numbers

### DIFF
--- a/lib/pronto/tslint_npm.rb
+++ b/lib/pronto/tslint_npm.rb
@@ -85,10 +85,9 @@ module Pronto
       output.map do |offence|
         {
           msg: offence['failure'],
-          line: offence['startPosition']['line']
+          line: offence['startPosition']['line'] + 1
         }
       end
-
     end
   end
 end

--- a/spec/pronto/tslint_spec.rb
+++ b/spec/pronto/tslint_spec.rb
@@ -30,11 +30,15 @@ module Pronto
         let(:patches) { repo.diff('master') }
 
         it 'returns correct number of errors' do
-          expect(run.count).to eql(6)
+          expect(run.count).to eql(7)
         end
 
         it 'has correct first message' do
           expect(run.first.msg).to eql("Forbidden 'var' keyword, use 'let' or 'const' instead")
+        end
+
+        it 'has correct first line number' do
+          expect(run.first.line.new_lineno).to eql(5)
         end
 
         context(


### PR DESCRIPTION
This fixes an issue where the previous line numbers are reported by Pronto due tslint using zero based numbering.