### PR TITLE
Update pronto to `0.10.0` version

### DIFF
--- a/pronto-tslint_npm.gemspec
+++ b/pronto-tslint_npm.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.requirements << 'tslint (in PATH)'
 
-  s.add_dependency('pronto', '~> 0.9.1')
+  s.add_dependency('pronto', '~> 0.10.0')
   s.add_development_dependency('rake', '>= 11.0', '< 13')
   s.add_development_dependency('rspec', '~> 3.4')
   s.add_development_dependency('byebug', '>= 9')


### PR DESCRIPTION
Update `gemspec` dependencies to use new `pronto` version. 